### PR TITLE
Check completion count messages of children after each batch

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ So you've decided to use Branson...
 Here are some things to know:
 
 - Branson is not an acronym.
-- Branson requires MPI 1.10+, Boost (headers only), Metis and ParMetis.
+- Branson requires MPI 3.0+, Boost (headers only), Metis and ParMetis.
 - The point of Branson is to study different algorithms for parallel
  Monte Carlo transport. Currently it contains particle passing and
  mesh passing methods for domain decomposition.

--- a/src/completion_manager.h
+++ b/src/completion_manager.h
@@ -77,6 +77,10 @@ class Completion_Manager
   //! End completion manager for the timestep by finishing communication
   virtual void end_timestep(Message_Counter& mctr) = 0;
 
+  //! Process receives from child ranks in binary tree
+  virtual void get_child_subtree_num_done(uint64_t& n_complete_tree,
+    Message_Counter& mctr) = 0;
+
   //! Adds completed work count to the global count
   virtual void process_completion(bool waiting_for_work,
                                   uint64_t& n_complete_tree,

--- a/src/completion_manager_rma.h
+++ b/src/completion_manager_rma.h
@@ -121,6 +121,12 @@ class Completion_Manager_RMA : public Completion_Manager
     }
   }
 
+
+  //! Check for completed particle counts from children, don't need to do this
+  //! There are no outstanding receive to process in the RMA mode
+  void get_child_subtree_num_done(uint64_t& n_complete_tree,
+    Message_Counter& mctr) {}
+
   //! Add number of completed particles to this tree count and get the number
   // of completed particles by your children (n_sends_posted is not used
   virtual void process_completion(bool waiting_for_work,

--- a/src/particle_pass_transport.h
+++ b/src/particle_pass_transport.h
@@ -397,6 +397,8 @@ std::vector<Photon> particle_pass_transport(Source& source,
     // binary tree completion communication
     //------------------------------------------------------------------------//
 
+    comp->get_child_subtree_num_done(n_complete, mctr);
+
     waiting_for_work = ((n_local_sourced == n_local) &&
       phtn_recv_stack.empty());
 


### PR DESCRIPTION
+ Add function to completion_manger to only check completion of receive
messages. This allows receiving counts to be decoupled from sending counts
and thus receives are processed even when particle work remains. Decoupling
this should results in fewer completion messages.
+ Change MPI requirement in README.txt to reference MPI standard number
instead of OpenMPI version number