### PR TITLE
suppress warning reported with clang

### DIFF
--- a/src/decompose_mesh.h
+++ b/src/decompose_mesh.h
@@ -891,7 +891,7 @@ void remap_cell_and_grip_indices_staged(Mesh *mesh, const int rank,
     int send_ranks_start = n * (n_rank / 8);
     int send_ranks_end = (n + 1) * (n_rank / 8);
     if (n == 7)
-      send_ranks_end == n_rank;
+      send_ranks_end = n_rank;
     int n_senders = send_ranks_end - send_ranks_start;
 
     std::vector<MPI_Request> id_reqs(n_senders);


### PR DESCRIPTION
clang was complaining about this-

In file included from /home/hpp/branson/src/main.cc:20:
/home/hpp/branson/src/decompose_mesh.h:894:22: warning: equality comparison result unused [-Wunused-comparison]
      send_ranks_end == n_rank;
      ~~~~~~~~~~~~~~~^~~~~~~~~
/home/hpp/branson/src/decompose_mesh.h:894:22: note: use '=' to turn this equality comparison into an assignment
      send_ranks_end == n_rank;
                     ^~
and it looks like the compiler is correct.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>