### PR TITLE
add hook for darwin so make test works

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required (VERSION 2.8)
 # Set OpenMPI compiler
 #set(CMAKE_CXX_COMPILER mpic++)
 
-if ("${SITENAME}" STREQUAL "Moonlight" OR ${SITENAME} MATCHES "ccscs[0-9]+" OR ${SITENAME} MATCHES "Snow" OR ${SITENAME} MATCHES "Badger")
+if ("${SITENAME}" STREQUAL "Moonlight" OR ${SITENAME} MATCHES "ccscs[0-9]+" OR ${SITENAME} MATCHES "Snow" OR ${SITENAME} MATCHES "Badger" OR ${SITENAME} MATCHES "darwin")
   set(MPI_EXEC mpirun)
 elseif (${SITENAME} STREQUAL "Trinitite")
   set(MPI_EXEC srun)


### PR DESCRIPTION
On darwin frontend, works automatically since
cmake site_name returns darwin.  On other nodes,
have to set

-DSITENAME=darwin

The darwin compute node names are too generic to
crack them using logic in top level CMakeLists.txt

Signed-off-by: Howard Pritchard <howardp@lanl.gov>