### PR TITLE
Add particle combing to branson lite

### DIFF
--- a/src/comb_photons.h
+++ b/src/comb_photons.h
@@ -24,7 +24,7 @@ void comb_photons(std::vector<Photon> &census_photons,
   uint64_t n_global_census = census_photons.size();
   MPI_Allreduce(MPI_IN_PLACE, &n_global_census, 1, MPI_UNSIGNED_LONG, MPI_SUM,
                 MPI_COMM_WORLD);
-  if ( n_global_census > max_census_photons) {
+  if (n_global_census > max_census_photons) {
     std::vector<Photon> post_comb_photons;
 
     double census_total_E = get_photon_list_E(census_photons);

--- a/src/comb_photons.h
+++ b/src/comb_photons.h
@@ -20,45 +20,51 @@ void comb_photons(std::vector<Photon> &census_photons,
   std::unordered_map<uint32_t, double> cell_census_E;
   std::unordered_map<uint32_t, double> cell_corrected_E;
 
-  std::vector<Photon> post_comb_photons;
-
-  double census_total_E = get_photon_list_E(census_photons);
-  double global_census_E = census_total_E;
-  MPI_Allreduce(MPI_IN_PLACE, &global_census_E, 1, MPI_DOUBLE, MPI_SUM,
+  // only comb if the photon population is too large
+  uint64_t n_global_census = census_photons.size();
+  MPI_Allreduce(MPI_IN_PLACE, &n_global_census, 1, MPI_UNSIGNED_LONG, MPI_SUM,
                 MPI_COMM_WORLD);
-  double comb_photon_E = global_census_E / double(max_census_photons);
+  if ( n_global_census > max_census_photons) {
+    std::vector<Photon> post_comb_photons;
 
-  for (auto &p : census_photons) {
-    cell_census_count[p.get_cell()]++;
-    cell_census_E[p.get_cell()] += p.get_E();
-  }
+    double census_total_E = get_photon_list_E(census_photons);
+    double global_census_E = census_total_E;
+    MPI_Allreduce(MPI_IN_PLACE, &global_census_E, 1, MPI_DOUBLE, MPI_SUM,
+                  MPI_COMM_WORLD);
+    double comb_photon_E = global_census_E / double(max_census_photons);
 
-  for (auto ip = census_photons.begin(); ip != census_photons.end(); ++ip) {
-    uint32_t cell = ip->get_cell();
-    double p_kill = 1.0 - ip->get_E() / comb_photon_E;
-    double rand_check = rng->generate_random_number();
-    // save the photon probabilistically or if there is only one photon
-    // remaining in the cell
-    if (rand_check > p_kill || cell_census_count[cell] == 1) {
-      ip->set_E(comb_photon_E);
-      cell_corrected_E[cell] += comb_photon_E;
-      post_comb_photons.push_back(*ip);
-    } else {
-      cell_census_count[cell]--;
+    for (auto &p : census_photons) {
+      cell_census_count[p.get_cell()]++;
+      cell_census_E[p.get_cell()] += p.get_E();
     }
-  }
 
-  // correct energy for conservation
-  double new_E;
-  uint32_t cell;
-  for (auto &p : post_comb_photons) {
-    cell = p.get_cell();
-    new_E = p.get_E() + (cell_census_E[cell] - cell_corrected_E[cell]) /
-                            double(cell_census_count[cell]);
-    p.set_E(new_E);
-  }
+    for (auto ip = census_photons.begin(); ip != census_photons.end(); ++ip) {
+      uint32_t cell = ip->get_cell();
+      double p_kill = 1.0 - ip->get_E() / comb_photon_E;
+      double rand_check = rng->generate_random_number();
+      // save the photon probabilistically or if there is only one photon
+      // remaining in the cell
+      if (rand_check > p_kill || cell_census_count[cell] == 1) {
+        ip->set_E(comb_photon_E);
+        cell_corrected_E[cell] += comb_photon_E;
+        post_comb_photons.push_back(*ip);
+      } else {
+        cell_census_count[cell]--;
+      }
+    }
 
-  census_photons = post_comb_photons;
+    // correct energy for conservation
+    double new_E;
+    uint32_t cell;
+    for (auto &p : post_comb_photons) {
+      cell = p.get_cell();
+      new_E = p.get_E() + (cell_census_E[cell] - cell_corrected_E[cell]) /
+                              double(cell_census_count[cell]);
+      p.set_E(new_E);
+    }
+
+    census_photons = post_comb_photons;
+  }
 }
 
 #endif // comb_photons_h_

--- a/src/replicated_driver.h
+++ b/src/replicated_driver.h
@@ -37,6 +37,11 @@ void imc_replicated_driver(Mesh &mesh, IMC_State &imc_state,
   int rank = mpi_info.get_rank();
   constexpr double fake_mpi_runtime = 0.0;
 
+  // set the max census size to be 10% more than the user requested photons.
+  // Note that this does not need to be divided by the number of ranks
+  // because the comb get the global census energy with an MPI_Allreduce
+  uint64_t max_census_size = static_cast<uint64_t>(1.1*imc_parameters.get_n_user_photon());
+
   if (imc_parameters.get_write_silo_flag()) {
     // write SILO file
     write_silo(mesh, imc_state.get_time(), imc_state.get_step(),
@@ -70,7 +75,7 @@ void imc_replicated_driver(Mesh &mesh, IMC_State &imc_state,
 
     // transport photons, return the particles that reached census
     census_photons =
-        replicated_transport(source, mesh, imc_state, abs_E, track_E);
+        replicated_transport(source, mesh, imc_state, abs_E, track_E, max_census_size);
 
     // reduce the abs_E and the track weighted energy (for T_r)
     MPI_Allreduce(MPI_IN_PLACE, &abs_E[0], mesh.get_global_num_cells(),

--- a/src/replicated_driver.h
+++ b/src/replicated_driver.h
@@ -40,7 +40,8 @@ void imc_replicated_driver(Mesh &mesh, IMC_State &imc_state,
   // set the max census size to be 10% more than the user requested photons.
   // Note that this does not need to be divided by the number of ranks
   // because the comb get the global census energy with an MPI_Allreduce
-  uint64_t max_census_size = static_cast<uint64_t>(1.1*imc_parameters.get_n_user_photon());
+  uint64_t max_census_size =
+      static_cast<uint64_t>(1.1 * imc_parameters.get_n_user_photon());
 
   if (imc_parameters.get_write_silo_flag()) {
     // write SILO file
@@ -74,8 +75,8 @@ void imc_replicated_driver(Mesh &mesh, IMC_State &imc_state,
     imc_state.set_transported_particles(source.get_n_photon());
 
     // transport photons, return the particles that reached census
-    census_photons =
-        replicated_transport(source, mesh, imc_state, abs_E, track_E, max_census_size);
+    census_photons = replicated_transport(source, mesh, imc_state, abs_E,
+                                          track_E, max_census_size);
 
     // reduce the abs_E and the track weighted energy (for T_r)
     MPI_Allreduce(MPI_IN_PLACE, &abs_E[0], mesh.get_global_num_cells(),

--- a/src/replicated_transport.h
+++ b/src/replicated_transport.h
@@ -20,11 +20,11 @@
 #include <vector>
 
 #include "RNG.h"
+#include "comb_photons.h"
 #include "constants.h"
 #include "info.h"
 #include "mesh.h"
 #include "photon.h"
-#include "comb_photons.h"
 #include "sampling_functions.h"
 #include "source.h"
 
@@ -162,7 +162,6 @@ std::vector<Photon> replicated_transport(Source &source, const Mesh &mesh,
 
   // replicated transport does not require the global photon count
   uint64_t n_local = source.get_n_photon();
-
 
   //------------------------------------------------------------------------//
   // main transport loop


### PR DESCRIPTION
This adds combing to the replicated transporter. Previously, replicated mode was just make sure there was no resource sharing between cores when evaluating cache effects. Now that it's being used for real problems in branson lite we need combing to keep the population count under control.