### PR TITLE
Fom output

### DIFF
--- a/src/imc_state.h
+++ b/src/imc_state.h
@@ -164,6 +164,10 @@ public:
   //! Get total transport time (max time summed across all timesteps)
   double get_total_transport_time(void) { return total_transport_time; }
 
+  double get_photons_per_second_fom(uint64_t photons) {
+    return (double) photons/total_transport_time;
+  }
+
   //--------------------------------------------------------------------------//
   // non-const functions                                                      //
   //--------------------------------------------------------------------------//

--- a/src/main.cc
+++ b/src/main.cc
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
       imc_state.print_simulation_footer(input.get_dd_mode());
       timers.print_timers();
       cout<<"Total transport: "<<imc_state.get_total_transport_time()<<endl;
-      cout<<"Photons Per Second (FOM):"<<
+      cout<<"Photons Per Second (FOM): "<<
         imc_state.get_photons_per_second_fom(imc_p.get_n_user_photon())<<endl;
     }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -112,6 +112,8 @@ int main(int argc, char **argv) {
       imc_state.print_simulation_footer(input.get_dd_mode());
       timers.print_timers();
       cout<<"Total transport: "<<imc_state.get_total_transport_time()<<endl;
+      cout<<"Photons Per Second (FOM):"<<
+        imc_state.get_photons_per_second_fom(imc_p.get_n_user_photon())<<endl;
     }
 
   } // end main loop scope, objects destroyed here


### PR DESCRIPTION
Hi Alex,

I modified branson to output the photons per second (FOM). It's pretty simple. I just added a get photons per second method to the imc_state class that takes the number of photons, converts it to double, and divides it by total transport time. This was requested by nvidia for benchmarking (didn't want to rely on an outside calculation which someone could mess up). The only reservation I have is it seems you've modified cout to limit the number of sig figs? I'm not sure, but it could exceed 6 digits.  

Anyway, I ran it on snow and it works.

Cheers,
Dan