### PR TITLE
Add a memory banner prinout

### DIFF
--- a/src/particle_pass_driver.h
+++ b/src/particle_pass_driver.h
@@ -77,6 +77,8 @@ void imc_particle_pass_driver(Mesh &mesh, IMC_State &imc_state,
 
     imc_state.set_transported_particles(all_photons.size());
 
+    imc_state.print_memory_estimate(rank, n_ranks, mesh.get_n_local_cells(), all_photons.size());
+
     // add barrier here to make sure the transport timer starts at roughly the same time
     MPI_Barrier(MPI_COMM_WORLD);
     census_photons = particle_pass_transport(mesh, gpu_setup, imc_parameters, mpi_info, mpi_types, imc_state, mctr, abs_E, track_E, all_photons);

--- a/src/particle_pass_transport.h
+++ b/src/particle_pass_transport.h
@@ -35,7 +35,7 @@
 
 std::vector<Photon> particle_pass_transport(
     const Mesh &mesh, const GPU_Setup &gpu_setup, const IMC_Parameters &imc_parameters, const Info &mpi_info, const MPI_Types &mpi_types,
-    IMC_State &imc_state, Message_Counter &mctr, std::vector<double> &rank_abs_E, std::vector<double> &rank_track_E, std::vector<Photon> all_photons) {
+    IMC_State &imc_state, Message_Counter &mctr, std::vector<double> &rank_abs_E, std::vector<double> &rank_track_E, std::vector<Photon> &all_photons, const int n_omp_threads) {
   using std::cout;
   using std::endl;
   using std::stack;

--- a/src/replicated_driver.h
+++ b/src/replicated_driver.h
@@ -78,6 +78,8 @@ void imc_replicated_driver(Mesh &mesh, IMC_State &imc_state,
 
     imc_state.set_transported_particles(all_photons.size());
 
+    imc_state.print_memory_estimate(rank, n_ranks,  mesh.get_n_local_cells(), all_photons.size());
+
     // add barrier here to make sure the transport timer starts at roughly the same time
     MPI_Barrier(MPI_COMM_WORLD);
 


### PR DESCRIPTION
+ Add a banner that prints out the photon distribution between timesteps
+ Estimate the node memory use by adding cell and photon memory
+ Clean up a very dumb copy of the photon array passed to the transporter