### PR TITLE
Umpire

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -147,16 +147,14 @@ void makeUmpireDevicePool(int device_pool_size) {
   device_pool_allocator.deallocate(tmp);
 }
 
-template<typename T>
-cudaError_t umpireMalloc(T** devPtr, size_t size) {
+cudaError_t umpireMalloc(void** devPtr, size_t size) {
   auto &rm = umpire::ResourceManager::getInstance();
   auto allocator = rm.getAllocator("BRANSON_DEVICE_POOL");
-  *devPtr = (T*) allocator.allocate(size);
+  *devPtr = allocator.allocate(size);
   return cudaSuccess;
 }
 
-template<typename T>
-cudaError_t umpireFree(T* devPtr) {
+cudaError_t umpireFree(void* devPtr) {
   auto &rm = umpire::ResourceManager::getInstance();
   auto allocator = rm.getAllocator("BRANSON_DEVICE_POOL");
   allocator.deallocate(devPtr);

--- a/src/history_based_transport.h
+++ b/src/history_based_transport.h
@@ -745,55 +745,55 @@ void gpu_transport_photons(const uint32_t rank_cell_offset,
 
   // Allocate SoA data on GPU
   uint32_t* d_cell_ID;
-  auto malloc_err = cudaMalloc(&d_cell_ID, n_photons * sizeof(uint32_t));
+  auto malloc_err = cudaMalloc((void**)&d_cell_ID, n_photons * sizeof(uint32_t));
   if (malloc_err) std::cout<<"Error allocating d_cell_ID"<<std::endl;
   auto copy_err = cudaMemcpy(d_cell_ID, cpu_photons.cell_ID.data(), n_photons * sizeof(uint32_t), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_cell_ID"<<std::endl;
 
   uint32_t* d_group;
-  malloc_err = cudaMalloc(&d_group, n_photons * sizeof(uint32_t));
+  malloc_err = cudaMalloc((void**)&d_group, n_photons * sizeof(uint32_t));
   if (malloc_err) std::cout<<"Error allocating d_group"<<std::endl;
   copy_err = cudaMemcpy(d_group, cpu_photons.group.data(), n_photons * sizeof(uint32_t), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_group"<<std::endl;
 
   unsigned char* d_descriptors;
-  malloc_err = cudaMalloc(&d_descriptors, n_photons * sizeof(unsigned char));
+  malloc_err = cudaMalloc((void**)&d_descriptors, n_photons * sizeof(unsigned char));
   if (malloc_err) std::cout<<"Error allocating d_descriptors"<<std::endl;
   copy_err = cudaMemcpy(d_descriptors, cpu_photons.descriptors.data(), n_photons * sizeof(unsigned char), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_decsriptors"<<std::endl;
 
   std::array<double, 3>* d_pos;
-  malloc_err = cudaMalloc(&d_pos, n_photons * sizeof(std::array<double, 3>));
+  malloc_err = cudaMalloc((void**)&d_pos, n_photons * sizeof(std::array<double, 3>));
   if (malloc_err) std::cout<<"Error allocating d_pos"<<std::endl;
   copy_err = cudaMemcpy(d_pos, cpu_photons.pos.data(), n_photons * sizeof(std::array<double, 3>), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_pos"<<std::endl;
 
   std::array<double, 3>* d_angle;
-  malloc_err = cudaMalloc(&d_angle, n_photons * sizeof(std::array<double, 3>));
+  malloc_err = cudaMalloc((void**)&d_angle, n_photons * sizeof(std::array<double, 3>));
   if (malloc_err) std::cout<<"Error allocating d_angle"<<std::endl;
   copy_err = cudaMemcpy(d_angle, cpu_photons.angle.data(), n_photons * sizeof(std::array<double, 3>), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_angle"<<std::endl;
 
   double* d_E;
-  malloc_err = cudaMalloc(&d_E, n_photons * sizeof(double));
+  malloc_err = cudaMalloc((void**)&d_E, n_photons * sizeof(double));
   if (malloc_err) std::cout<<"Error allocating d_E"<<std::endl;
   copy_err = cudaMemcpy(d_E, cpu_photons.E.data(), n_photons * sizeof(double), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_E"<<std::endl;
 
   double* d_E0;
-  malloc_err = cudaMalloc(&d_E0, n_photons * sizeof(double));
+  malloc_err = cudaMalloc((void**)&d_E0, n_photons * sizeof(double));
   if (malloc_err) std::cout<<"Error allocating d_E0"<<std::endl;
   copy_err = cudaMemcpy(d_E0, cpu_photons.E0.data(), n_photons * sizeof(double), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_E0"<<std::endl;
 
   double* d_life_dx;
-  malloc_err = cudaMalloc(&d_life_dx, n_photons * sizeof(double));
+  malloc_err = cudaMalloc((void**)&d_life_dx, n_photons * sizeof(double));
   if (malloc_err) std::cout<<"Error allocating d_life_dx"<<std::endl;
   copy_err = cudaMemcpy(d_life_dx, cpu_photons.life_dx.data(), n_photons * sizeof(double), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_life_dx"<<std::endl;
 
   RNG* d_rng;
-  malloc_err = cudaMalloc(&d_rng, n_photons * sizeof(RNG));
+  malloc_err = cudaMalloc((void**)&d_rng, n_photons * sizeof(RNG));
   if (malloc_err) std::cout<<"Error allocating d_rng"<<std::endl;
   copy_err = cudaMemcpy(d_rng, cpu_photons.rng.data(), n_photons * sizeof(RNG), cudaMemcpyHostToDevice);
   if (copy_err) std::cout<<"Error copying d_rng"<<std::endl;

--- a/src/input.h
+++ b/src/input.h
@@ -525,6 +525,7 @@ public:
       MPI_Bcast(&n_photons, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
       MPI_Bcast(all_doubles.data(), all_doubles.size(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
       MPI_Bcast(regions.data(), n_regions, MPI_Region, 0, MPI_COMM_WORLD);
+      MPI_Bcast(&umpire_device_pool_size, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
 
       vector<uint32_t> division_key;
       vector<uint32_t> region_at_division;
@@ -600,6 +601,7 @@ public:
       // region processing (broadcast directly into member variable)
       regions.resize(n_regions);
       MPI_Bcast(&regions[0], n_regions, MPI_Region, 0, MPI_COMM_WORLD);
+      MPI_Bcast(&umpire_device_pool_size, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
 
       vector<uint32_t> division_key(n_divisions);
       vector<uint32_t> region_at_division(n_divisions);

--- a/src/test/test_warp_reductions.cc
+++ b/src/test/test_warp_reductions.cc
@@ -61,7 +61,7 @@ int test_inc_ballot_all_true() {
 
   std::cout<<"alloc"<<std::endl;
   unsigned int* d_counter;
-  auto err = cudaMalloc(&d_counter, sizeof(unsigned int));
+  auto err = cudaMalloc((void**)&d_counter, sizeof(unsigned int));
   Insist(!err, "error in malloc");
   err = cudaMemset(d_counter, 0, sizeof(unsigned int));
   Insist(!err, "error in memset");


### PR DESCRIPTION
This PR adds Umpire to branson
1. A build option `USE_UMPIRE` is added to optionally build with Umpire enabled. This option is only valid for GPU builds (i.e. when either `USE_CUDA` or `USE_HIP` is enabled). `USE_UMPIRE` is ignored for non-GPU builds
2. When `USE_UMPIRE=ON`,  the code creates an Umpire device memory pool at program initialization. The size of the device memory pool (in GB, default 4GB) can be specified using the input tag `umpire_device_pool_size` in the input xml. Any GPU memory allocations are then handled through this device pool
3. When `USE_UMPIRE=ON`, the code prints the device memory high water mark at the end.