### PR TITLE
hip + umpire malloc fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@
 
 cmake_minimum_required (VERSION 3.24)
 
+option(USE_UMPIRE "Use Umpire" FALSE)
 option(USE_CUDA "Use CUDA" FALSE)
 option(USE_HIP "Use HIP" FALSE)
 option(USE_GPU "user-set flag to compile in GPU code" FALSE)
@@ -154,6 +155,18 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -DR123_USE_GNU_UINT128=0")
 endif()
 
+##############################################################################
+# umpire
+##############################################################################
+if(USE_CUDA OR USE_HIP)
+  if(USE_UMPIRE)
+    message(STATUS "Looking for umpire...")
+    find_package(umpire REQUIRED)
+    message(STATUS "Looking for umpire......found ${umpire_DIR}")
+    list(APPEND branson_deps umpire)
+  endif()
+endif()
+
 
 #------------------------------------------------------------------------------#
 # Look for Third Party Libraries (metis, etc.)
@@ -254,13 +267,12 @@ if("${GPU_DBS_STRING}" STREQUAL "CUDA" )
   else()
     message("Setting CUDA compiler options")
     #set_target_properties(BRANSON PROPERTIES CUDA_ARCHITECTURES "90") # H100
-    #set_target_properties(BRANSON PROPERTIES CUDA_ARCHITECTURES "70") # V100
-    set_target_properties(BRANSON PROPERTIES CUDA_ARCHITECTURES "80") # A100
+    set_target_properties(BRANSON PROPERTIES CUDA_ARCHITECTURES "70") # V100
+    #set_target_properties(BRANSON PROPERTIES CUDA_ARCHITECTURES "80") # A100
     set_target_properties(BRANSON PROPERTIES CUDA_STANDARD 17)
     string(APPEND CMAKE_CUDA_FLAGS " -g --expt-relaxed-constexpr --fmad=false -lineinfo")
     string(APPEND CMAKE_CUDA_FLAGS " --expt-extended-lambda"  )
     set_source_files_properties("main.cc" PROPERTIES LANGUAGE CUDA)
-
     message("Making GPU(CUDA) BRANSON")
   endif()
 elseif("${GPU_DBS_STRING}" STREQUAL "HIP" )

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -26,6 +26,7 @@
 #cmakedefine CCS_NODE
 
 #cmakedefine USE_OPENMP
+#cmakedefine USE_UMPIRE
 
 // For faux multigroup array sizing
 #cmakedefine BRANSON_N_GROUPS @BRANSON_N_GROUPS@
@@ -75,7 +76,11 @@ static constexpr uint32_t WARP_SIZE=64;
 #define cudaDeviceReset hipDeviceReset
 #define cudaDeviceSynchronize hipDeviceSynchronize
 #define cudaError_t hipError_t
+#ifdef USE_UMPIRE
+#define cudaFree umpireFree
+#else
 #define cudaFree hipFree
+#endif
 #define cudaGetDevice hipGetDevice
 #define cudaGetDeviceCount hipGetDeviceCount
 #define cudaGetDeviceProperties hipGetDeviceProperties
@@ -93,6 +98,10 @@ static constexpr uint32_t WARP_SIZE=64;
 #endif // USE_HIP
 
 #ifdef USE_CUDA
+#ifdef USE_UMPIRE
+#define cudaFree umpireFree
+#define cudaMalloc umpireMalloc
+#endif
 
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -78,8 +78,10 @@ static constexpr uint32_t WARP_SIZE=64;
 #define cudaError_t hipError_t
 #ifdef USE_UMPIRE
 #define cudaFree umpireFree
+#define cudaMalloc umpireMalloc
 #else
 #define cudaFree hipFree
+#define cudaMalloc hipMalloc
 #endif
 #define cudaGetDevice hipGetDevice
 #define cudaGetDeviceCount hipGetDeviceCount
@@ -87,7 +89,6 @@ static constexpr uint32_t WARP_SIZE=64;
 #define cudaGetErrorName hipGetErrorName
 #define cudaGetErrorString hipGetErrorString
 #define cudaGetLastError hipGetLastError
-#define cudaMalloc hipMalloc
 #define cudaMemcpy hipMemcpy
 #define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
 #define cudaMemcpyHostToDevice hipMemcpyHostToDevice

--- a/src/input.h
+++ b/src/input.h
@@ -154,6 +154,12 @@ public:
         use_gpu_transporter = 0;
       }
 
+#ifdef USE_GPU
+#ifdef USE_UMPIRE
+      umpire_device_pool_size = settings_node.child("umpire_device_pool_size").text().as_int();
+#endif
+#endif
+
       // use particle combing population control
       tempString = settings_node.child_value("use_combing");
       if (tempString == "FALSE")
@@ -190,7 +196,7 @@ public:
         dd_mode = REPLICATED;
       }
 
-      // particle storage type 
+      // particle storage type
       tempString = settings_node.child_value("particle_storage");
       if (tempString == "AOS")
         particle_storage = AOS;
@@ -202,7 +208,7 @@ public:
         particle_storage = AOS;
       }
 
-      // particle storage type 
+      // particle storage type
       tempString = settings_node.child_value("particle_algorithm");
       if (tempString == "EVENT")
         particle_algorithm = EVENT;
@@ -501,7 +507,7 @@ public:
                             use_gpu_transporter};
     vector<uint32_t> all_uint = {seed, dd_mode, decomp_mode, particle_storage, particle_algorithm,
                                   n_omp_threads, output_freq, batch_size, particle_message_size,
-                                  n_divisions, n_global_x_cells, n_global_y_cells, n_global_z_cells, 
+                                  n_divisions, n_global_x_cells, n_global_y_cells, n_global_z_cells,
                                   n_regions, n_x_div, n_y_div, n_z_div};
 
     vector<double> all_doubles = {tStart, dt, tFinish, tMult,  dtMax, T_source};
@@ -519,8 +525,11 @@ public:
       MPI_Bcast(&n_photons, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
       MPI_Bcast(all_doubles.data(), all_doubles.size(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
       MPI_Bcast(regions.data(), n_regions, MPI_Region, 0, MPI_COMM_WORLD);
+      #ifdef USE_GPU
+      #ifdef USE_UMPIRE
       MPI_Bcast(&umpire_device_pool_size, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
-
+      #endif
+      #endif
       vector<uint32_t> division_key;
       vector<uint32_t> region_at_division;
       for (auto rmap : region_map) {
@@ -595,7 +604,11 @@ public:
       // region processing (broadcast directly into member variable)
       regions.resize(n_regions);
       MPI_Bcast(&regions[0], n_regions, MPI_Region, 0, MPI_COMM_WORLD);
+      #ifdef USE_GPU
+      #ifdef USE_UMPIRE
       MPI_Bcast(&umpire_device_pool_size, 1, MPI_UNSIGNED, 0, MPI_COMM_WORLD);
+      #endif
+      #endif
 
       vector<uint32_t> division_key(n_divisions);
       vector<uint32_t> region_at_division(n_divisions);
@@ -833,6 +846,12 @@ public:
   int get_rng_seed() const { return seed; }
   //! Return the number of photons set in the input file to run
   uint64_t get_number_photons() const { return n_photons; }
+#ifdef USE_GPU
+#ifdef USE_UMPIRE
+  //! Return the device memory pool size in GB
+  uint32_t get_umpire_device_pool_size() const { return umpire_device_pool_size; }
+#endif
+#endif
   //! Return the batch size (particles to run between parallel processing)
   uint32_t get_batch_size() const { return batch_size; }
   //! Return the user requested number of particles in a message
@@ -841,9 +860,9 @@ public:
   }
   //! Return the domain decomposition algorithm
   uint32_t get_dd_mode() const { return dd_mode; }
-  //! Return the particle storage type 
+  //! Return the particle storage type
   uint32_t get_particle_storage() const { return particle_storage; }
-  //! Return the particle storage type 
+  //! Return the particle storage type
   uint32_t get_particle_algorithm() const { return particle_algorithm; }
 
   //! Return the domain decomposition algorithm
@@ -911,13 +930,19 @@ private:
 
   // Parallel parameters
   uint32_t dd_mode;     //!< Mode of domain decomposed transport algorithm
-  uint32_t particle_storage; //!< Particle array storage type 
+  uint32_t particle_storage; //!< Particle array storage type
   uint32_t particle_algorithm; //!< Event-based or history-based
   uint32_t decomp_mode; //!< Mode of decomposing mesh
   uint32_t n_omp_threads; //!< Number of OpenMP threads, 1 if no OpenMP
 
   // Debug parameters
   uint32_t output_freq; //!< How often to print temperature information
+
+#ifdef USE_GPU
+#ifdef USE_UMPIRE
+  uint32_t umpire_device_pool_size = 4; //!< Size (in GB) of the device memory pool
+#endif
+#endif
 
   // Bools
   bool use_comb;        //!< Comb census photons

--- a/src/main.cc
+++ b/src/main.cc
@@ -79,6 +79,12 @@ int main(int argc, char **argv) {
     if (mpi_info.get_rank() == 0)
       input.print_problem_info();
 
+#ifdef USE_GPU
+#ifdef USE_UMPIRE
+    makeUmpireDevicePool(input.get_umpire_device_pool_size());
+#endif
+#endif
+
     // IMC paramters setup
     IMC_Parameters imc_p(input);
 
@@ -155,6 +161,12 @@ int main(int argc, char **argv) {
       cout<<"Total transport: "<<imc_state.get_total_transport_time()<<endl;
       cout<<"Photons Per Second (FOM): "<<
         imc_state.get_photons_per_second_fom(imc_p.get_n_user_photons())<<endl;
+#ifdef USE_GPU
+#ifdef USE_UMPIRE
+      cout<<"Umpire device memory pool size: "<<input.get_umpire_device_pool_size()<<" GB"<<endl;
+      cout<<"Umpire device memory high water mark: "<<getDeviceMemoryHighWatermark()<<" GB"<<endl;
+#endif
+#endif
     }
 
   } // end main loop scope, objects destroyed here


### PR DESCRIPTION
`USE_HIP` + `USE_UMPIRE` hitting a runtime error when Umpire is attempting to free memory.

Defining `cudaMalloc` as `umpireMalloc`