### PR TITLE
Fix caliper annotations

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -18,7 +18,7 @@
 
 #cmakedefine VIZ_LIBRARIES_FOUND
 #cmakedefine METIS_FOUND
-#cmakedefine caliper_FOUND
+#cmakedefine USE_CALIPER
 #cmakedefine MOONLIGHT_NODE
 #cmakedefine SNOW_NODE
 #cmakedefine TRINITITE_NODE
@@ -41,7 +41,7 @@
 #include <omp.h>
 #endif
 
-#ifdef caliper_FOUND
+#ifdef USE_CALIPER
 #include <caliper/cali.h>
 #endif
 
@@ -324,7 +324,7 @@ inline void device_debug_print(size_t n_photons, const std::string &alg_type) {}
 
 #endif // USE_GPU
 
-#ifdef caliper_FOUND
+#ifdef USE_CALIPER
 
 /*
 void wrapped_cali_mark_begin(const char *timer_name) {

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -18,7 +18,7 @@
 
 #cmakedefine VIZ_LIBRARIES_FOUND
 #cmakedefine METIS_FOUND
-#cmakedefine USE_CALIPER
+#cmakedefine caliper_FOUND
 #cmakedefine MOONLIGHT_NODE
 #cmakedefine SNOW_NODE
 #cmakedefine TRINITITE_NODE
@@ -41,7 +41,7 @@
 #include <omp.h>
 #endif
 
-#ifdef USE_CALIPER
+#ifdef caliper_FOUND
 #include <caliper/cali.h>
 #endif
 
@@ -324,7 +324,7 @@ inline void device_debug_print(size_t n_photons, const std::string &alg_type) {}
 
 #endif // USE_GPU
 
-#ifdef USE_CALIPER
+#ifdef caliper_FOUND
 
 /*
 void wrapped_cali_mark_begin(const char *timer_name) {

--- a/src/timer.h
+++ b/src/timer.h
@@ -17,10 +17,6 @@
 #include <string>
 #include <unordered_map>
 
-#ifdef caliper_FOUND
-#include <caliper/cali.h>
-#endif
-
 class Timer {
 public:
   Timer(void) {}
@@ -29,7 +25,7 @@ public:
   //! Start or continute timer with name
   void start_timer(std::string name) {
 #ifdef caliper_FOUND
-    CALI_MARK_BEGIN(name);
+    CALI_MARK_BEGIN(name.c_str());
 #else
     // start timer if new
     if (times.find(name) == times.end())
@@ -41,7 +37,7 @@ public:
   //! Stop timer with name (must be the last active timer)
   void stop_timer(std::string name) {
 #ifdef caliper_FOUND
-    CALI_MARK_END(name);
+    CALI_MARK_END(name.c_str());
 #else
     double time_seconds =
         std::chrono::duration_cast<std::chrono::microseconds>(

--- a/src/timer.h
+++ b/src/timer.h
@@ -26,7 +26,7 @@ public:
 
   //! Start or continute timer with name
   void start_timer(std::string name) {
-#ifdef caliper_FOUND
+#ifdef USE_CALIPER
     CALI_MARK_BEGIN(name);
 #else
     // start timer if new
@@ -38,7 +38,7 @@ public:
 
   //! Stop timer with name (must be the last active timer)
   void stop_timer(std::string name) {
-#ifdef caliper_FOUND
+#ifdef USE_CALIPER
     CALI_MARK_END(name);
 #else
     double time_seconds =
@@ -52,7 +52,7 @@ public:
 
   //! Print all timers that have been measured with this clsas
   void print_timers(void) const {
-#ifndef caliper_FOUND
+#ifndef USE_CALIPER
     for (auto const &i_time : times) {
       std::cout << i_time.first << ": " << i_time.second << std::endl;
     }
@@ -61,7 +61,7 @@ public:
 
   //! Get the current elapsed time for a timer
   double get_time(std::string name) {
-#ifndef caliper_FOUND
+#ifndef USE_CALIPER
     return times[name];
 #endif
   }

--- a/src/timer.h
+++ b/src/timer.h
@@ -17,6 +17,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "config.h"
+
 class Timer {
 public:
   Timer(void) {}

--- a/src/timer.h
+++ b/src/timer.h
@@ -17,7 +17,9 @@
 #include <string>
 #include <unordered_map>
 
-#include "config.h"
+#ifdef caliper_FOUND
+#include <caliper/cali.h>
+#endif
 
 class Timer {
 public:
@@ -26,7 +28,7 @@ public:
 
   //! Start or continute timer with name
   void start_timer(std::string name) {
-#ifdef USE_CALIPER
+#ifdef caliper_FOUND
     CALI_MARK_BEGIN(name);
 #else
     // start timer if new
@@ -38,7 +40,7 @@ public:
 
   //! Stop timer with name (must be the last active timer)
   void stop_timer(std::string name) {
-#ifdef USE_CALIPER
+#ifdef caliper_FOUND
     CALI_MARK_END(name);
 #else
     double time_seconds =
@@ -52,7 +54,7 @@ public:
 
   //! Print all timers that have been measured with this clsas
   void print_timers(void) const {
-#ifndef USE_CALIPER
+#ifndef caliper_FOUND
     for (auto const &i_time : times) {
       std::cout << i_time.first << ": " << i_time.second << std::endl;
     }
@@ -61,7 +63,7 @@ public:
 
   //! Get the current elapsed time for a timer
   double get_time(std::string name) {
-#ifndef USE_CALIPER
+#ifndef caliper_FOUND
     return times[name];
 #endif
   }


### PR DESCRIPTION
Caliper annotations `CALI_MARK_BEGIN` and `CALI_MARK_END` expect a C-style string as input. This PR fixes the caliper input parameter in branson by converting it from C++ `std::string` to the C-style `const char*`