### PR TITLE
adiak/caliper/umpire fixes

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -14,6 +14,7 @@
 #define config_h_
 
 #include <mpi.h>
+#include <cstddef>
 #include <cstdint>
 
 #cmakedefine VIZ_LIBRARIES_FOUND
@@ -78,6 +79,10 @@ static constexpr uint32_t WARP_SIZE=64;
 #define cudaDeviceSynchronize hipDeviceSynchronize
 #define cudaError_t hipError_t
 #ifdef USE_UMPIRE
+cudaError_t umpireMalloc(void** devPtr, size_t size);
+cudaError_t umpireFree(void* devPtr);
+template <typename T>
+cudaError_t umpireMalloc(T** devPtr, size_t size);
 #define cudaMalloc umpireMalloc
 #define cudaFree umpireFree
 #else
@@ -100,13 +105,16 @@ static constexpr uint32_t WARP_SIZE=64;
 #endif // USE_HIP
 
 #ifdef USE_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
 #ifdef USE_UMPIRE
+cudaError_t umpireMalloc(void** devPtr, size_t size);
+cudaError_t umpireFree(void* devPtr);
+template <typename T>
+cudaError_t umpireMalloc(T** devPtr, size_t size);
 #define cudaFree umpireFree
 #define cudaMalloc umpireMalloc
 #endif
-
-#include <cuda.h>
-#include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
@@ -149,6 +157,14 @@ cudaError_t umpireMalloc(void** devPtr, size_t size) {
   auto allocator = rm.getAllocator("BRANSON_DEVICE_POOL");
   *devPtr = allocator.allocate(size);
   return cudaSuccess;
+}
+
+template <typename T>
+cudaError_t umpireMalloc(T** devPtr, size_t size) {
+  void* raw_ptr = nullptr;
+  auto err = umpireMalloc(&raw_ptr, size);
+  *devPtr = static_cast<T*>(raw_ptr);
+  return err;
 }
 
 cudaError_t umpireFree(void* devPtr) {

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -43,6 +43,7 @@
 
 #ifdef caliper_FOUND
 #include <caliper/cali.h>
+#include <adiak.hpp>
 #endif
 
 // since the main.cc as marked as a CUDA file in CUDA mode, this allows the tests to compile

--- a/src/decompose_mesh.h
+++ b/src/decompose_mesh.h
@@ -609,10 +609,12 @@ void decompose_mesh(Proto_Mesh &mesh, const MPI_Types &mpi_types,
 
   // decomposition methods return a partition vector which is the rank of each cell
   std::vector<int> part;
+  std::cout << "On rank: " << rank << ":: decomposition type " << decomposition_type << std::endl;
   if (decomposition_type == CUBE) {
     part = cube_partition(mesh, rank, n_rank);
     edgecut = 1;
   } else if (decomposition_type == METIS) {
+    std::cout << "On rank: " << rank << ":: METIS decomposition" << std::endl;
     if (n_rank > 1) {
 #ifdef METIS_FOUND
       part = metis_partition(mesh, edgecut, rank, n_rank, mpi_types);
@@ -652,11 +654,13 @@ void decompose_mesh(Proto_Mesh &mesh, const MPI_Types &mpi_types,
   remap_cell_and_grip_indices_allreduce(mesh, rank, n_rank);
   t_remap.stop_timer("remap");
 
+#ifndef caliper_FOUND
   if (rank == 0) {
     std::cout << "Partition: " << t_partition.get_time("partition")<<" seconds"
               << std::endl;
     std::cout << "Remap: " << t_remap.get_time("remap") <<" seconds"<<std::endl;
   }
+#endif
 }
 
 //! Create replicated mesh by giving all cells to all other processors, renumber

--- a/src/decompose_mesh.h
+++ b/src/decompose_mesh.h
@@ -609,12 +609,10 @@ void decompose_mesh(Proto_Mesh &mesh, const MPI_Types &mpi_types,
 
   // decomposition methods return a partition vector which is the rank of each cell
   std::vector<int> part;
-  std::cout << "On rank: " << rank << ":: decomposition type " << decomposition_type << std::endl;
   if (decomposition_type == CUBE) {
     part = cube_partition(mesh, rank, n_rank);
     edgecut = 1;
   } else if (decomposition_type == METIS) {
-    std::cout << "On rank: " << rank << ":: METIS decomposition" << std::endl;
     if (n_rank > 1) {
 #ifdef METIS_FOUND
       part = metis_partition(mesh, edgecut, rank, n_rank, mpi_types);

--- a/src/main.cc
+++ b/src/main.cc
@@ -78,6 +78,13 @@ int main(int argc, char **argv) {
     if (mpi_info.get_rank() == 0)
       input.print_problem_info();
 
+#ifdef caliper_FOUND
+    MPI_Comm adiak_mpi_comm = MPI_COMM_WORLD;
+    void* adiak_mpi_comm_ptr = &adiak_mpi_comm;
+    adiak::init(adiak_mpi_comm_ptr);
+    adiak::collect_all();
+#endif
+
 #ifdef USE_GPU
 #ifdef USE_UMPIRE
     makeUmpireDevicePool(input.get_umpire_device_pool_size());
@@ -149,6 +156,10 @@ int main(int argc, char **argv) {
 
     timers.stop_timer("Total");
 
+#ifdef caliper_FOUND
+    adiak::fini();
+#endif
+
     if (mpi_info.get_rank() == 0) {
       cout << "****************************************";
       cout << "****************************************" << endl;
@@ -161,7 +172,19 @@ int main(int argc, char **argv) {
 #ifdef USE_UMPIRE
       cout<<"Umpire device memory pool size: "<<input.get_umpire_device_pool_size()<<" GB"<<endl;
       cout<<"Umpire device memory high water mark: "<<getDeviceMemoryHighWatermark()<<" GB"<<endl;
+#ifdef caliper_FOUND
+      adiak::value("umpire_device_pool_size", input.get_umpire_device_pool_size());
+      adiak::value("umpire_device_high_water_mark", getDeviceMemoryHighWatermark());
 #endif
+#endif
+#endif
+
+#ifdef caliper_FOUND
+    adiak::value("num_particles", imc_p.get_n_user_photons());
+    adiak::value("fom", imc_state.get_photons_per_second_fom(imc_p.get_n_user_photons()));
+    adiak::value("particle_storage", (input.get_particle_storage() == Constants::AOS) ? "AOS" : "SOA");
+    adiak::value("decomposition_mode", (input.get_dd_mode() == Constants::REPLICATED) ? "PARTICLE_PASS" : "REPLICATED");
+    adiak::value("particle_algorithm", (input.get_particle_algorithm() == Constants::EVENT) ? "EVENT" : "HISTORY");
 #endif
     }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -142,7 +142,7 @@ int main(int argc, char **argv) {
       else if( input.get_particle_storage() == SOA) {
         timers.start_timer("replicated soa");
         imc_replicated_driver<PhotonArray>(mesh, imc_state, imc_p, mpi_types, mpi_info);
-        timers.start_timer("replicated soa");
+        timers.stop_timer("replicated soa");
       }
       else {
         cout << "Driver for array currently not supported" << endl;

--- a/src/main.cc
+++ b/src/main.cc
@@ -182,6 +182,7 @@ int main(int argc, char **argv) {
 #ifdef caliper_FOUND
     adiak::value("num_particles", imc_p.get_n_user_photons());
     adiak::value("fom", imc_state.get_photons_per_second_fom(imc_p.get_n_user_photons()));
+    adiak::value("n_groups", BRANSON_N_GROUPS);
     adiak::value("particle_storage", (input.get_particle_storage() == Constants::AOS) ? "AOS" : "SOA");
     adiak::value("decomposition_mode", (input.get_dd_mode() == Constants::REPLICATED) ? "PARTICLE_PASS" : "REPLICATED");
     adiak::value("particle_algorithm", (input.get_particle_algorithm() == Constants::EVENT) ? "EVENT" : "HISTORY");

--- a/src/timer.h
+++ b/src/timer.h
@@ -61,6 +61,8 @@ public:
   double get_time(std::string name) {
 #ifndef caliper_FOUND
     return times[name];
+#else
+    return 0.0;
 #endif
   }
 


### PR DESCRIPTION
This PR 
- Adds branson input variables and, when using umpire, the memory pool size and high water mark to adiak
- Fixes bugs pertaining to caliper in the timer class 
- Fixes a bug in the CUDA allocator definition when using Umpire pools