### PR TITLE
Use command line parameters to override common xml input values

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -27,6 +27,8 @@
 #include "mpi_types.h"
 #include "region.h"
 
+using CommonInputOverrides = std::map<std::string, std::string>;
+
 //==============================================================================
 /*!
  * \class Input
@@ -40,7 +42,8 @@
 class Input {
 public:
   //! Constructor
-  Input(std::string fileName, const MPI_Types &mpi_types) {
+  Input(std::string fileName, const MPI_Types &mpi_types,
+        const CommonInputOverrides &common_overrides = CommonInputOverrides()) {
     using Constants::ELEMENT;
     using Constants::REFLECT;
     using Constants::VACUUM;
@@ -123,6 +126,15 @@ public:
       if (!region_node) {
         std::cout << "'regions' section not found!" << std::endl;
         exit(EXIT_FAILURE);
+      }
+
+      // Command-line values override the XML common block before parsing.
+      for (CommonInputOverrides::const_iterator it = common_overrides.begin();
+           it != common_overrides.end(); ++it) {
+        pugi::xml_node child = settings_node.child(it->first.c_str());
+        if (!child)
+          child = settings_node.append_child(it->first.c_str());
+        child.text().set(it->second.c_str());
       }
 
       tFinish = settings_node.child("t_stop").text().as_double();

--- a/src/main.cc
+++ b/src/main.cc
@@ -10,6 +10,7 @@
 //---------------------------------------------------------------------------//
 
 #include <iostream>
+#include <algorithm>
 #include <string>
 #include <sys/time.h>
 #include <time.h>
@@ -36,14 +37,96 @@ using std::endl;
 using std::string;
 using std::vector;
 
-int main(int argc, char **argv) {
-  MPI_Init(&argc, &argv);
+namespace {
 
-  // check to see if number of arguments is correct
-  if (argc != 2) {
-    cout << "Usage: BRANSON <path_to_input_file>" << endl;
+struct ParsedCommandLine {
+  ParsedCommandLine() : show_help(false) {}
+
+  bool show_help;
+  std::string input_file;
+  CommonInputOverrides common_overrides;
+};
+
+void print_usage() {
+  cout << "Usage: BRANSON <path_to_input_file> "
+       << "[--common-tag value | --common-tag=value] ..." << endl;
+  cout << "Common-section overrides use the XML tag name. Hyphens are converted"
+       << " to underscores, so --t-stop overrides <t_stop>." << endl;
+}
+
+std::string normalize_common_key(std::string key) {
+  const std::string common_prefix("common.");
+  if (key.compare(0, common_prefix.size(), common_prefix) == 0)
+    key = key.substr(common_prefix.size());
+  std::replace(key.begin(), key.end(), '-', '_');
+  return key;
+}
+
+ParsedCommandLine parse_command_line(int argc, char **argv) {
+  ParsedCommandLine parsed;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg(argv[i]);
+    if (arg == "-h" || arg == "--help") {
+      parsed.show_help = true;
+      return parsed;
+    }
+
+    if (arg.compare(0, 2, "--") == 0) {
+      std::string key_value = arg.substr(2);
+      std::string key;
+      std::string value;
+      const size_t equals_pos = key_value.find('=');
+      if (equals_pos != std::string::npos) {
+        key = key_value.substr(0, equals_pos);
+        value = key_value.substr(equals_pos + 1);
+      } else {
+        if (i + 1 >= argc) {
+          cout << "Missing value for command-line override: " << arg << endl;
+          print_usage();
+          exit(EXIT_FAILURE);
+        }
+        key = key_value;
+        value = argv[++i];
+      }
+
+      if (key.empty()) {
+        cout << "Invalid command-line override: " << arg << endl;
+        print_usage();
+        exit(EXIT_FAILURE);
+      }
+      parsed.common_overrides[normalize_common_key(key)] = value;
+      continue;
+    }
+
+    if (parsed.input_file.empty()) {
+      parsed.input_file = arg;
+      continue;
+    }
+
+    cout << "Unexpected positional argument: " << arg << endl;
+    print_usage();
     exit(EXIT_FAILURE);
   }
+
+  if (parsed.input_file.empty()) {
+    print_usage();
+    exit(EXIT_FAILURE);
+  }
+
+  return parsed;
+}
+
+} // end anonymous namespace
+
+int main(int argc, char **argv) {
+  ParsedCommandLine command_line = parse_command_line(argc, argv);
+  if (command_line.show_help) {
+    print_usage();
+    return EXIT_SUCCESS;
+  }
+
+  MPI_Init(&argc, &argv);
 
   // wrap main loop scope so objcts are destroyed before mpi_finalize is called
   {
@@ -73,8 +156,7 @@ int main(int argc, char **argv) {
     MPI_Types mpi_types;
 
     // get input object from filename
-    std::string filename(argv[1]);
-    Input input(filename, mpi_types);
+    Input input(command_line.input_file, mpi_types, command_line.common_overrides);
     if (mpi_info.get_rank() == 0)
       input.print_problem_info();
 

--- a/src/test/simple_input.xml
+++ b/src/test/simple_input.xml
@@ -11,7 +11,7 @@
     <output_frequency>1</output_frequency>
     <stratified_sampling>FALSE</stratified_sampling>
     <dd_transport_type>PARTICLE_PASS</dd_transport_type>
-    <dd_batch_size>1000</event_batch_size>
+    <dd_batch_size>1000</dd_batch_size>
     <event_batch_size>777</event_batch_size>
     <map_size>50000</map_size>
     <batch_size>10000</batch_size>

--- a/src/test/test_input.cc
+++ b/src/test/test_input.cc
@@ -23,6 +23,8 @@ int main(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
 
   using Constants::REPLICATED;
+  using Constants::SOA;
+  using Constants::EVENT;
   using Constants::REFLECT;
   using Constants::VACUUM;
   using Constants::X_NEG;
@@ -147,6 +149,82 @@ int main(int argc, char *argv[]) {
         cout << "TEST PASSED: simple input get functions" << endl;
       else {
         cout << "TEST FAILED: simple input get functions" << endl;
+        nfail++;
+      }
+    }
+
+    // test command-line style overrides applied to the common input block while
+    // leaving unspecified values on their XML defaults.
+    {
+      string filename("simple_input.xml");
+      CommonInputOverrides common_overrides;
+      common_overrides["t_start"] = "0.25";
+      common_overrides["t_stop"] = "0.5";
+      common_overrides["dt_start"] = "0.125";
+      common_overrides["t_mult"] = "1.5";
+      common_overrides["dt_max"] = "2.0";
+      common_overrides["photons"] = "123456";
+      common_overrides["seed"] = "8675309";
+      common_overrides["output_frequency"] = "9";
+      common_overrides["dd_transport_type"] = "REPLICATED";
+      common_overrides["particle_storage"] = "SOA";
+      common_overrides["particle_algorithm"] = "EVENT";
+      common_overrides["n_omp_threads"] = "8";
+      common_overrides["dd_batch_size"] = "2468";
+      common_overrides["event_batch_size"] = "1357";
+      common_overrides["particle_message_size"] = "4321";
+      common_overrides["use_gpu_transporter"] = "TRUE";
+      common_overrides["use_combing"] = "TRUE";
+      common_overrides["write_silo"] = "TRUE";
+
+      Input input(filename, mpi_types, common_overrides);
+
+      bool common_override_pass = true;
+      if (input.get_dt() != 0.125)
+        common_override_pass = false;
+      if (input.get_time_start() != 0.25)
+        common_override_pass = false;
+      if (input.get_time_finish() != 0.5)
+        common_override_pass = false;
+      if (input.get_time_mult() != 1.5)
+        common_override_pass = false;
+      if (input.get_dt_max() != 2.0)
+        common_override_pass = false;
+      if (input.get_rng_seed() != 8675309)
+        common_override_pass = false;
+      if (input.get_number_photons() != 123456)
+        common_override_pass = false;
+      if (input.get_output_freq() != 9)
+        common_override_pass = false;
+      if (input.get_dd_mode() != REPLICATED)
+        common_override_pass = false;
+      if (input.get_particle_storage() != SOA)
+        common_override_pass = false;
+      if (input.get_particle_algorithm() != EVENT)
+        common_override_pass = false;
+      if (input.get_n_omp_threads() != 8)
+        common_override_pass = false;
+      if (input.get_dd_batch_size() != 2468)
+        common_override_pass = false;
+      if (input.get_event_batch_size() != 1357)
+        common_override_pass = false;
+      if (input.get_particle_message_size() != 4321)
+        common_override_pass = false;
+      if (input.get_use_gpu_transporter_bool() != true)
+        common_override_pass = false;
+      if (input.get_comb_bool() != true)
+        common_override_pass = false;
+      if (input.get_write_silo_bool() != true)
+        common_override_pass = false;
+      if (input.get_global_n_x_cells() != 10)
+        common_override_pass = false;
+      if (input.get_bc(X_NEG) != REFLECT)
+        common_override_pass = false;
+
+      if (common_override_pass)
+        cout << "TEST PASSED: common section overrides" << endl;
+      else {
+        cout << "TEST FAILED: common section overrides" << endl;
         nfail++;
       }
     }

--- a/src/test/three_region_mesh_input.xml
+++ b/src/test/three_region_mesh_input.xml
@@ -11,7 +11,7 @@
     <output_frequency>1</output_frequency>
     <stratified_sampling>FALSE</stratified_sampling>
     <dd_transport_type>PARTICLE_PASS</dd_transport_type>
-    <dd_batch_size>1000</event_batch_size>
+    <dd_batch_size>1000</dd_batch_size>
     <event_batch_size>5000</event_batch_size>
     <map_size>50000</map_size>
     <batch_size>10000</batch_size>


### PR DESCRIPTION
This PR:
1. Adds the option to set from the command line any input parameters enclosed within the tags `<common>...</common>` in the input xml file.
2. The value from the command line overrides any value for a variable specified in the xml file.
3. If no value is provided for an input parameter on the command line, the value in the xml file is used.