### PR TITLE
Fix cmake for HIP builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,15 @@ get_property(_LANGUAGES_ GLOBAL PROPERTY ENABLED_LANGUAGES)
 
 find_package(MPI REQUIRED C CXX)
 
+set(branson_mpi_include_dirs
+  ${MPI_C_INCLUDE_DIRS}
+  ${MPI_CXX_INCLUDE_DIRS}
+  ${MPI_C_ADDITIONAL_INCLUDE_DIRS}
+  ${MPI_CXX_ADDITIONAL_INCLUDE_DIRS}
+  ${MPI_C_COMPILER_INCLUDE_DIRS}
+  ${MPI_CXX_COMPILER_INCLUDE_DIRS})
+list(REMOVE_DUPLICATES branson_mpi_include_dirs)
+
 list(APPEND branson_deps
   MPI::MPI_C
   MPI::MPI_CXX)
@@ -240,7 +249,10 @@ endif()
 file(GLOB headers *.h)
 add_executable(BRANSON main.cc ${headers})
 target_include_directories( BRANSON PRIVATE
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> ${PROJECT_SOURCE_DIR}/pugixml/src/ ${PROJECT_SOURCE_DIR}/random123/ )
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+  ${PROJECT_SOURCE_DIR}/pugixml/src/
+  ${PROJECT_SOURCE_DIR}/random123/
+  ${branson_mpi_include_dirs} )
 
 if("${GPU_DBS_STRING}" STREQUAL "CUDA" )
   if(USE_CUDA)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -47,7 +47,8 @@ function( add_branson_test )
   # Build the test
   add_executable( ${build_target} ${abt_SOURCE} )
   target_include_directories( ${build_target} PRIVATE
-    $<BUILD_INTERFACE:${BRANSON_BINARY_DIR}> )
+    $<BUILD_INTERFACE:${BRANSON_BINARY_DIR}>
+    ${branson_mpi_include_dirs} )
   target_link_libraries( ${build_target} PUBLIC ${branson_deps} )
 
   # Register the test command with ctest.
@@ -74,7 +75,8 @@ function( add_branson_gpu_test )
   # Build the test
   add_executable( ${build_target} ${abt_SOURCE} )
   target_include_directories( ${build_target} PRIVATE
-    $<BUILD_INTERFACE:${BRANSON_BINARY_DIR}> )
+    $<BUILD_INTERFACE:${BRANSON_BINARY_DIR}>
+    ${branson_mpi_include_dirs} )
   target_link_libraries( ${build_target} PUBLIC ${branson_deps} )
 
   if("${GPU_DBS_STRING}" STREQUAL "CUDA" )


### PR DESCRIPTION
We (@rfhaque and I) are hitting a build error on Tuolumne for HIP.
```
            0: fatal error: 'mpi.h' file not found
     146       16 | #include <mpi.h>
     147          |          ^~~~~~~
     148    1 error generated when compiling for gfx942.
```

I've tested these changes to the CMake fix the build error.