### PR TITLE
Fix DD prints and bad merge

### DIFF
--- a/src/gpu_setup.h
+++ b/src/gpu_setup.h
@@ -84,7 +84,7 @@ public:
   }
 
   // re-sync data
-  void update_cells_and_reset_tallies(const int rank, const std::vector<Cell> &cpu_cells, uint64_t n_user_photons) {
+  void update_cells_and_reset_tallies(const int rank, const int n_ranks, const std::vector<Cell> &cpu_cells, uint64_t n_user_photons) {
       host_cells_ptr = cpu_cells.data();
       // Precompute emission group data for event-based transport (both CPU and GPU) and reset
       // tallies

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -386,6 +386,21 @@ public:
       }
       // domain decomposed mode
       else {
+        // gather data using original global cell index
+        std::vector<double> global_T_e(n_global, 0.0);
+        std::vector<double> global_T_r(n_global, 0.0);
+        std::vector<double> global_abs_E(n_global, 0.0);
+
+        for (uint32_t i = 0; i < n_cell; ++i) {
+          const Cell &e = cells[i];
+          auto original_global_cell_index = e.get_silo_index();
+          global_T_e[original_global_cell_index] = e.get_T_e();
+          global_T_r[original_global_cell_index] = T_r[i];
+          global_abs_E[original_global_cell_index] = abs_E[i];
+        }
+        MPI_Allreduce(MPI_IN_PLACE, global_T_e.data(), global_T_e.size(), MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(MPI_IN_PLACE, global_T_r.data(), global_T_r.size(), MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(MPI_IN_PLACE, global_abs_E.data(), global_abs_E.size(), MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
         if (rank == 0) {
           std::cout.precision(8);
           std::cout<<"-------- VERBOSE PRINT BLOCK: CELL TEMPERATURE --------"<<std::endl;
@@ -394,24 +409,17 @@ public:
           std::cout<<setiosflags(ios::right) << setw(12) << "T_r"<<" ";
           std::cout<<setiosflags(ios::right) << setw(12) << "abs_E"<<" ";
           std::cout<<std::endl;
-        }
-        // ranks take turns writing out cell data for ordered cell output in domain decomposed mode
-        for (int write_rank =0; write_rank < n_ranks; ++write_rank) {
-          if(rank == write_rank) {
-            for (uint32_t i = 0; i < n_cell; ++i) {
-              const Cell &e = cells[i];
-              std::cout<<setiosflags(ios::right) << setw(12) << e.get_global_index()<<" ";
-              std::cout<<setiosflags(ios::right) << setw(12) << e.get_T_e()<<" ";
-              std::cout<<setiosflags(ios::right) << setw(12) << T_r[i]<<" ";
-              std::cout<<setiosflags(ios::right) << setw(12) << abs_E[i]<<" ";
-              std::cout<<std::endl;
-            }
+          for (uint32_t i = 0; i < n_global;++i) {
+            std::cout<<setiosflags(ios::right) << setw(12) << i<<" ";
+            std::cout<<setiosflags(ios::right) << setw(12) << global_T_e[i]<<" ";
+            std::cout<<setiosflags(ios::right) << setw(12) << global_T_r[i]<<" ";
+            std::cout<<setiosflags(ios::right) << setw(12) << global_abs_E[i];
+            std::cout<<std::endl;
+            std::cout<<std::flush;
           }
-          MPI_Barrier(MPI_COMM_WORLD);
-          std::cout<<std::flush;
+          std::cout<<"-------------------------------------------------------"<<std::endl;
         }
-      if (rank == 0)
-        std::cout<<"-------------------------------------------------------"<<std::endl;
+      MPI_Barrier(MPI_COMM_WORLD);
       }
     } // end verbose print block
 

--- a/src/particle_pass_driver.h
+++ b/src/particle_pass_driver.h
@@ -60,7 +60,7 @@ void imc_particle_pass_driver(Mesh &mesh, IMC_State &imc_state,
     mesh.calculate_photon_energy(imc_state, n_user_photons);
 
     // reset gpu setup with new mesh cells, reset tallies, and update emission group data
-    gpu_setup.update_cells_and_reset_tallies(rank, mesh.get_cells(), n_user_photons);
+    gpu_setup.update_cells_and_reset_tallies(rank, n_ranks, mesh.get_cells(), n_user_photons);
 
     // all reduce to get total source energy to make correct number of
     // particles on each rank

--- a/src/replicated_driver.h
+++ b/src/replicated_driver.h
@@ -61,7 +61,7 @@ void imc_replicated_driver(Mesh &mesh, IMC_State &imc_state,
     mesh.calculate_photon_energy(imc_state, n_user_photons);
 
     // reset gpu setup with new mesh cells, reset tallies, and update emission group data
-    gpu_setup.update_cells_and_reset_tallies(rank, mesh.get_cells(), n_user_photons);
+    gpu_setup.update_cells_and_reset_tallies(rank, n_ranks, mesh.get_cells(), n_user_photons);
 
     // all reduce to get total source energy to make correct number of articles on each rank
     double global_source_energy = mesh.get_total_photon_E();


### PR DESCRIPTION
* Missed some changes from the reserve fix, now passing n_ranks to the gpu_setup call
* Verbose prints in domain decomposed runs were giving cells out of order. This PR fixes that by gathering all the data to rank 0 (obviously bad from memory but  this is probably a bad way to dump mesh state on big problems). DD and Replicated printing matches now.